### PR TITLE
Reduce table input font size

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -69,9 +69,14 @@ body {
   padding-right: 0;
 }
 
+.table tbody td {
+  font-size: 0.85rem;
+}
+
 .table tbody td .form-control {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   font-weight: 500;
+  line-height: 1.3;
 }
 
 .table tbody td .form-control:focus {


### PR DESCRIPTION
## Summary
- reduce the font size of table cells and inputs so student information fits better within each box
- adjust table input line height to maintain readability with the smaller text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2721c8bc83289c8e92fb96cbba96