### PR TITLE
Validate pipeline before processing Pipedrive deals

### DIFF
--- a/netlify/functions/fetch-deal.js
+++ b/netlify/functions/fetch-deal.js
@@ -51,6 +51,14 @@ exports.handler = async (event) => {
       });
     }
 
+    const pipelineId = extractEntityId(deal.pipeline_id);
+    if (pipelineId === null || Number(pipelineId) !== 3) {
+      return jsonResponse(400, {
+        success: false,
+        message: 'El presupuesto pedido no es de formación en abierto'
+      });
+    }
+
     const trainingDate = deal[TRAINING_DATE_FIELD] || '';
     const rawTrainingLocation = await resolveDealFieldOptionValue(
       baseUrl,


### PR DESCRIPTION
## Summary
- verify that fetched Pipedrive deals belong to the "formación en abierto" pipeline before continuing
- return a descriptive error when the requested deal is in a different pipeline

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2878fd988328bea820058199f4d4