### PR TITLE
Adjust hero layout and budget form sizing

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -21,20 +21,28 @@ body {
 
 .hero-section {
   background: linear-gradient(135deg, rgba(44, 92, 197, 0.12), rgba(44, 92, 197, 0));
+  padding: 1.5rem 0 1rem;
+}
+
+.hero-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
 .hero-logo {
-  max-width: 260px;
-  width: 100%;
+  width: 130px;
   height: auto;
   display: block;
-  margin: 1.5rem auto;
 }
 
 .hero-title {
   font-size: clamp(2rem, 4vw, 2.75rem);
   font-weight: 600;
   color: #1f274d;
+  margin: 0;
+  text-align: left;
 }
 
 .text-bg-primary-soft {
@@ -45,6 +53,26 @@ body {
 
 .card {
   border-radius: var(--brand-radius);
+}
+
+.budget-card .card-body {
+  padding: 1.5rem;
+}
+
+@media (min-width: 992px) {
+  .hero-section {
+    padding: 2rem 0 1.5rem;
+  }
+
+  .budget-card .card-body {
+    padding: 2rem 2.5rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .hero-header {
+    align-items: flex-start;
+  }
 }
 
 .table thead th {
@@ -109,6 +137,10 @@ body {
 @media (max-width: 991.98px) {
   .card-body {
     padding: 2rem;
+  }
+
+  .budget-card .card-body {
+    padding: 1.5rem;
   }
 
   .table-responsive {

--- a/public/index.html
+++ b/public/index.html
@@ -21,20 +21,15 @@
   </head>
   <body>
     <main class="page-wrapper">
-      <section class="hero-section py-5">
+      <section class="hero-section">
         <div class="container">
-          <div class="row justify-content-center text-center">
-            <div class="col-lg-8">
-              <div class="badge rounded-pill text-bg-primary-soft mb-3">
-                GEP Group · Certificados
-              </div>
-              <img
-                src="assets/GEP-Group_Logotipo_horizontal.png"
-                alt="Logotipo GEP Group"
-                class="hero-logo"
-              />
-              <h1 class="hero-title">Certificados Formación Abierta</h1>
-            </div>
+          <div class="hero-header">
+            <img
+              src="assets/GEP-Group_Logotipo_horizontal.png"
+              alt="Logotipo GEP Group"
+              class="hero-logo"
+            />
+            <h1 class="hero-title">Certificados Formación Abierta</h1>
           </div>
         </div>
       </section>
@@ -43,8 +38,8 @@
         <div class="container">
           <div id="alert-container" class="mb-4" aria-live="polite"></div>
 
-          <div class="card border-0 shadow-sm mb-4">
-            <div class="card-body p-4 p-lg-5">
+          <div class="card border-0 shadow-sm mb-4 budget-card">
+            <div class="card-body">
               <form id="budget-form" class="row g-3 align-items-end">
                 <div class="col-lg-8">
                   <label for="budget-input" class="form-label fw-medium"
@@ -52,7 +47,7 @@
                   >
                   <input
                     type="text"
-                    class="form-control form-control-lg"
+                    class="form-control"
                     id="budget-input"
                     name="budget"
                     placeholder="ejemplo: 6574,6456,7366,etc...!"
@@ -63,7 +58,7 @@
                 <div class="col-lg-4">
                   <button
                     type="submit"
-                    class="btn btn-primary btn-lg w-100 d-flex align-items-center justify-content-center gap-2"
+                    class="btn btn-primary w-100 d-flex align-items-center justify-content-center gap-2"
                     id="fill-button"
                   >
                     <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- reposition the hero header so the logo sits on the top-left beside the "Certificados Formación Abierta" heading
- shrink the hero logo and tighten hero spacing to move the content upward
- reduce the budget form card padding and input/button sizing so the budget box looks more compact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4afeba30832896524cdf3d2ee1d1