### PR TITLE
Add contextual tooltips to student fields

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -111,6 +111,45 @@ body {
   background-color: rgba(44, 92, 197, 0.08);
 }
 
+.table tbody td[data-tooltip] {
+  position: relative;
+}
+
+.table tbody td[data-tooltip]:hover::after,
+.table tbody td[data-tooltip]:focus-within::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.5rem);
+  transform: translateX(-50%);
+  background-color: #1f274d;
+  color: #ffffff;
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  box-shadow: 0 8px 18px rgba(31, 39, 77, 0.2);
+  max-width: min(240px, 85vw);
+  white-space: normal;
+  text-align: center;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.table tbody td[data-tooltip]:hover::before,
+.table tbody td[data-tooltip]:focus-within::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.25rem);
+  transform: translateX(-50%) rotate(45deg);
+  width: 0.6rem;
+  height: 0.6rem;
+  background-color: #1f274d;
+  z-index: 9;
+  pointer-events: none;
+}
+
 .table tbody td .document-wrapper {
   display: flex;
   align-items: center;

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -100,12 +100,19 @@
       TABLE_COLUMNS.forEach((column) => {
         const td = document.createElement('td');
         td.dataset.label = column.label;
+        const tooltipText = column.placeholder || column.label;
+        if (tooltipText) {
+          td.dataset.tooltip = tooltipText;
+        }
 
         if (column.field === 'dni') {
           const wrapper = document.createElement('div');
           wrapper.className = 'document-wrapper';
 
           const input = createInput(column, row[column.field], index);
+          if (tooltipText) {
+            input.title = tooltipText;
+          }
           const badge = document.createElement('span');
           badge.className = 'badge rounded-pill text-bg-info-subtle document-badge';
           updateDocumentBadge(badge, row.documentType);
@@ -123,6 +130,9 @@
           td.appendChild(wrapper);
         } else {
           const input = createInput(column, row[column.field], index);
+          if (tooltipText) {
+            input.title = tooltipText;
+          }
           input.addEventListener('input', (event) => {
             updateRowValue(index, column.field, event.target.value);
           });
@@ -154,6 +164,9 @@
     input.type = column.type === 'number' ? 'number' : column.type;
     input.placeholder = column.placeholder || '';
     input.value = column.type === 'date' ? normaliseDateValue(value) : value || '';
+    if (column.label) {
+      input.setAttribute('aria-label', column.label);
+    }
     if (column.type === 'number') {
       input.min = '0';
       input.step = '0.5';


### PR DESCRIPTION
## Summary
- add tooltip metadata to each editable cell using the existing column configuration
- render a custom tooltip on hover/focus so the helper text appears in a small bubble
- expose the column label to assistive tech through aria-labels on the generated inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc60e314008328b9adf789dd9ef6d9