### PR TITLE
Add PDF certificate generation template

### DIFF
--- a/public/assets/certificados/README.md
+++ b/public/assets/certificados/README.md
@@ -1,0 +1,11 @@
+# Assets del certificado
+
+Este directorio debe contener los recursos gráficos utilizados por la plantilla PDF de los certificados. Los ficheros deben subirse manualmente para que la generación del PDF utilice la identidad visual completa.
+
+| Nombre del archivo | Descripción | Recomendaciones |
+| ------------------ | ----------- | --------------- |
+| `fondo-certificado.png` | Figura roja que actúa como fondo en el margen derecho. | Imagen en formato PNG con transparencia. Ancho recomendado ~350-400 px para A4 apaisado. |
+| `lateral-izquierdo.png` | Elemento vertical con la identidad corporativa situado en el margen izquierdo. | Altura suficiente para cubrir todo el alto del documento (A4 apaisado ≈ 595 pt). |
+| `pie-firma.png` | Bloque con firma y logotipos que se coloca en la esquina inferior izquierda. | Utiliza transparencia para integrarse correctamente con el fondo. Ancho recomendado ~220-260 px. |
+
+> Los nombres de archivo deben coincidir exactamente con los listados arriba. El generador aplica una imagen transparente de reserva si no encuentra alguno de los recursos para evitar errores en tiempo de ejecución.

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -180,12 +180,24 @@
 
       const actionsTd = document.createElement('td');
       actionsTd.className = 'text-center';
+      const actionsWrapper = document.createElement('div');
+      actionsWrapper.className = 'd-flex flex-column flex-sm-row gap-2 justify-content-center';
+
+      const pdfButton = document.createElement('button');
+      pdfButton.type = 'button';
+      pdfButton.className = 'btn btn-primary btn-sm';
+      pdfButton.textContent = 'Generar PDF';
+      pdfButton.addEventListener('click', () => handleGeneratePdf(index, pdfButton));
+
       const deleteButton = document.createElement('button');
       deleteButton.type = 'button';
       deleteButton.className = 'btn btn-outline-danger btn-sm';
       deleteButton.textContent = 'Eliminar';
       deleteButton.addEventListener('click', () => removeRow(index));
-      actionsTd.appendChild(deleteButton);
+
+      actionsWrapper.appendChild(pdfButton);
+      actionsWrapper.appendChild(deleteButton);
+      actionsTd.appendChild(actionsWrapper);
       tr.appendChild(actionsTd);
 
       tableBody.appendChild(tr);
@@ -263,6 +275,42 @@
 
     badge.classList.remove('d-none');
     badge.textContent = documentType;
+  }
+
+  function handleGeneratePdf(rowIndex, triggerButton) {
+    const row = state.rows[rowIndex];
+    if (!row) {
+      showAlert('danger', 'No se ha encontrado la fila seleccionada.');
+      return;
+    }
+
+    if (!window.certificatePdf || typeof window.certificatePdf.generate !== 'function') {
+      showAlert('danger', 'La librería de certificados no está disponible.');
+      return;
+    }
+
+    let originalLabel = '';
+    if (triggerButton instanceof HTMLButtonElement) {
+      originalLabel = triggerButton.textContent;
+      triggerButton.disabled = true;
+      triggerButton.textContent = 'Generando...';
+    }
+
+    window.certificatePdf
+      .generate(row)
+      .then(() => {
+        showAlert('success', 'Certificado generado correctamente.');
+      })
+      .catch((error) => {
+        console.error('No se ha podido generar el certificado PDF', error);
+        showAlert('danger', 'No se ha podido generar el certificado en PDF. Revisa los datos e inténtalo de nuevo.');
+      })
+      .finally(() => {
+        if (triggerButton instanceof HTMLButtonElement) {
+          triggerButton.disabled = false;
+          triggerButton.textContent = originalLabel || 'Generar PDF';
+        }
+      });
   }
 
   async function handleBudgetSubmit(event) {

--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -1,0 +1,256 @@
+(function (global) {
+  const TRANSPARENT_PIXEL =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQI12NkYGD4DwABBAEAi5JBSwAAAABJRU5ErkJggg==';
+
+  const ASSET_PATHS = {
+    background: 'assets/certificados/fondo-certificado.png',
+    leftSidebar: 'assets/certificados/lateral-izquierdo.png',
+    footer: 'assets/certificados/pie-firma.png'
+  };
+
+  const assetCache = new Map();
+
+  function getCachedAsset(key) {
+    if (assetCache.has(key)) {
+      return assetCache.get(key);
+    }
+    const promise = loadImageAsDataUrl(ASSET_PATHS[key]).catch((error) => {
+      console.warn(`No se ha podido cargar el recurso "${key}" (${ASSET_PATHS[key]}).`, error);
+      return TRANSPARENT_PIXEL;
+    });
+    assetCache.set(key, promise);
+    return promise;
+  }
+
+  async function loadImageAsDataUrl(path) {
+    if (!path) {
+      return TRANSPARENT_PIXEL;
+    }
+    const response = await fetch(path);
+    if (!response.ok) {
+      throw new Error(`Respuesta ${response.status} al cargar ${path}`);
+    }
+    const blob = await response.blob();
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result);
+      reader.onerror = () => reject(new Error(`No se ha podido leer el archivo ${path}`));
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  function normaliseText(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function buildFullName(row) {
+    const name = normaliseText(row.nombre);
+    const surname = normaliseText(row.apellido);
+    return [name, surname].filter(Boolean).join(' ').trim() || 'Nombre del alumno/a';
+  }
+
+  function buildDocumentSentence(row) {
+    const documentType = normaliseText(row.documentType).toUpperCase();
+    const documentNumber = normaliseText(row.dni);
+    if (!documentType && !documentNumber) {
+      return 'con documento de identidad';
+    }
+    if (!documentType) {
+      return `con documento ${documentNumber}`;
+    }
+    if (!documentNumber) {
+      return `con ${documentType}`;
+    }
+    return `con ${documentType} ${documentNumber}`;
+  }
+
+  function formatTrainingDate(value) {
+    const normalised = normaliseText(value);
+    if (!normalised) {
+      return '________';
+    }
+    const parsed = new Date(normalised);
+    if (Number.isNaN(parsed.getTime())) {
+      return normalised;
+    }
+    const formatter = new Intl.DateTimeFormat('es-ES', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    });
+    return formatter.format(parsed);
+  }
+
+  function formatLocation(value) {
+    return normaliseText(value) || '________';
+  }
+
+  function formatDuration(value) {
+    if (value === undefined || value === null || value === '') {
+      return '____';
+    }
+    const numberValue = Number(value);
+    if (Number.isNaN(numberValue)) {
+      return normaliseText(value);
+    }
+    return numberValue % 1 === 0 ? String(numberValue) : numberValue.toLocaleString('es-ES');
+  }
+
+  function formatTrainingName(value) {
+    return normaliseText(value) || 'Nombre de la formación';
+  }
+
+  function buildFileName(row) {
+    const name = buildFullName(row).toLowerCase();
+    const safeName = name
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+    const dealId = normaliseText(row.presupuesto);
+    const suffix = dealId ? `-${dealId}` : '';
+    const base = safeName || 'certificado';
+    return `${base}${suffix}.pdf`;
+  }
+
+  function buildDocStyles() {
+    return {
+      bodyText: {
+        fontSize: 14,
+        lineHeight: 1.4
+      },
+      introText: {
+        fontSize: 14,
+        lineHeight: 1.5,
+        margin: [0, 0, 0, 12]
+      },
+      certificateTitle: {
+        fontSize: 34,
+        bold: true,
+        color: '#c4143c',
+        letterSpacing: 3,
+        margin: [0, 8, 0, 12]
+      },
+      highlighted: {
+        fontSize: 16,
+        bold: true,
+        margin: [0, 8, 0, 8]
+      },
+      trainingName: {
+        fontSize: 20,
+        bold: true,
+        margin: [0, 16, 0, 0]
+      }
+    };
+  }
+
+  async function buildDocDefinition(row) {
+    const [backgroundImage, sidebarImage, footerImage] = await Promise.all([
+      getCachedAsset('background'),
+      getCachedAsset('leftSidebar'),
+      getCachedAsset('footer')
+    ]);
+
+    const pageMargins = [150, 70, 180, 110];
+    const fullName = buildFullName(row);
+    const documentSentence = buildDocumentSentence(row);
+    const trainingDate = formatTrainingDate(row.fecha);
+    const location = formatLocation(row.lugar);
+    const duration = formatDuration(row.duracion);
+    const trainingName = formatTrainingName(row.formacion);
+
+    const contentStack = [
+      {
+        text: 'Sr. Lluís Vicent Pérez,\nDirector de la escuela GEPCO Formación\nexpide el presente:',
+        style: 'introText'
+      },
+      { text: 'CERTIFICADO', style: 'certificateTitle' },
+      { text: `A nombre del alumno/a ${fullName}`, style: 'bodyText' },
+      {
+        text: `${documentSentence}, quien en fecha ${trainingDate} y en ${location}`,
+        style: 'bodyText'
+      },
+      {
+        text: `ha superado, con una duración total de ${duration} horas, la formación de:`,
+        style: 'bodyText'
+      },
+      { text: trainingName, style: 'trainingName' },
+      { text: '\n\n', margin: [0, 0, 0, 0] }
+    ];
+
+    const docDefinition = {
+      pageOrientation: 'landscape',
+      pageSize: 'A4',
+      pageMargins,
+      background: function (currentPage, pageSize) {
+        const pageWidth = pageSize.width || 841.89;
+        const pageHeight = pageSize.height || 595.28;
+        const sidebarWidth = Math.min(120, pageWidth * 0.14);
+        const backgroundWidth = Math.min(380, pageWidth * 0.45);
+        const footerWidth = Math.min(260, pageWidth * 0.3);
+        const footerHeight = footerWidth * 0.28;
+        return [
+          {
+            image: sidebarImage,
+            width: sidebarWidth,
+            height: pageHeight,
+            absolutePosition: { x: 0, y: 0 }
+          },
+          {
+            image: backgroundImage,
+            width: backgroundWidth,
+            absolutePosition: { x: pageWidth - backgroundWidth, y: 0 }
+          },
+          {
+            image: footerImage,
+            width: footerWidth,
+            absolutePosition: { x: pageMargins[0], y: pageHeight - footerHeight - pageMargins[3] }
+          }
+        ];
+      },
+      content: [
+        {
+          margin: [0, 40, 0, 0],
+          stack: contentStack
+        }
+      ],
+      styles: buildDocStyles(),
+      defaultStyle: {
+        fontSize: 14,
+        lineHeight: 1.5,
+        color: '#1f274d'
+      },
+      info: {
+        title: `Certificado - ${fullName}`,
+        author: 'GEPCO Formación',
+        subject: trainingName
+      }
+    };
+
+    return docDefinition;
+  }
+
+  async function generateCertificate(row) {
+    if (!global.pdfMake || typeof global.pdfMake.createPdf !== 'function') {
+      throw new Error('pdfMake no está disponible.');
+    }
+    const docDefinition = await buildDocDefinition(row || {});
+    const fileName = buildFileName(row || {});
+
+    return new Promise((resolve, reject) => {
+      try {
+        global.pdfMake.createPdf(docDefinition).download(fileName, () => resolve({ fileName }));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  global.certificatePdf = {
+    generate: generateCertificate,
+    buildDocDefinition
+  };
+})(window);

--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,9 @@
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
       crossorigin="anonymous"
     ></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/pdfmake@0.2.7/build/pdfmake.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/pdfmake@0.2.7/build/vfs_fonts.js"></script>
+    <script src="assets/js/certificate-pdf.js" defer></script>
     <script src="assets/js/brand-assets.js" defer></script>
     <script src="assets/js/app.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- integrate pdfmake to generate certificates in formato apaisado con la nueva plantilla
- añadir módulo de certificados que maqueta el contenido con los elementos gráficos corporativos
- incorporar botón "Generar PDF" en cada alumno y documentar los assets necesarios para la plantilla

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc700e8290832895cbbf08bcfdd252