### PR TITLE
Fix tooltip visibility for last table row

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -150,6 +150,18 @@ body {
   pointer-events: none;
 }
 
+.table tbody tr:last-child td[data-tooltip]:hover::after,
+.table tbody tr:last-child td[data-tooltip]:focus-within::after {
+  top: auto;
+  bottom: calc(100% + 0.5rem);
+}
+
+.table tbody tr:last-child td[data-tooltip]:hover::before,
+.table tbody tr:last-child td[data-tooltip]:focus-within::before {
+  top: auto;
+  bottom: calc(100% + 0.25rem);
+}
+
 .table tbody td .document-wrapper {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- adjust tooltip styles to flip the direction on the final table row
- ensure last-row tooltips are displayed above the cell to remain visible inside the table container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc750c14fc832885c751ce23666db0