### PR TITLE
Adjust certificate layout and typography

### DIFF
--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -15,6 +15,19 @@
     logo: 382 / 827
   };
 
+  const FONT_SOURCES = {
+    'Poppins-Regular.ttf':
+      'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-400-normal.ttf',
+    'Poppins-Italic.ttf':
+      'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-400-italic.ttf',
+    'Poppins-SemiBold.ttf':
+      'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-600-normal.ttf',
+    'Poppins-SemiBoldItalic.ttf':
+      'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-600-italic.ttf'
+  };
+
+  let poppinsFontPromise = null;
+
   const assetCache = new Map();
 
   function getCachedAsset(key) {
@@ -44,6 +57,98 @@
       reader.onerror = () => reject(new Error(`No se ha podido leer el archivo ${path}`));
       reader.readAsDataURL(blob);
     });
+  }
+
+  async function loadFontAsBase64(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Respuesta ${response.status} al cargar ${url}`);
+    }
+    const buffer = await response.arrayBuffer();
+    return arrayBufferToBase64(buffer);
+  }
+
+  function arrayBufferToBase64(buffer) {
+    let binary = '';
+    const bytes = new Uint8Array(buffer);
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const chunk = bytes.subarray(i, i + chunkSize);
+      binary += String.fromCharCode.apply(null, chunk);
+    }
+    if (typeof global.btoa === 'function') {
+      return global.btoa(binary);
+    }
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(binary, 'binary').toString('base64');
+    }
+    throw new Error('No se puede convertir el buffer en base64 en este entorno.');
+  }
+
+  async function ensurePoppinsFont() {
+    const { pdfMake } = global;
+    if (!pdfMake) {
+      return;
+    }
+    if (pdfMake.fonts && pdfMake.fonts.Poppins) {
+      return;
+    }
+    if (!poppinsFontPromise) {
+      poppinsFontPromise = (async () => {
+        try {
+          const fontEntries = await Promise.all(
+            Object.entries(FONT_SOURCES).map(async ([name, url]) => {
+              try {
+                const data = await loadFontAsBase64(url);
+                return [name, data];
+              } catch (error) {
+                console.warn(`No se ha podido cargar la fuente Poppins (${name}).`, error);
+                return null;
+              }
+            })
+          );
+
+          const validEntries = fontEntries.filter(Boolean);
+          if (validEntries.length) {
+            pdfMake.vfs = pdfMake.vfs || {};
+            validEntries.forEach(([name, data]) => {
+              pdfMake.vfs[name] = data;
+            });
+          }
+
+          const existingFonts = pdfMake.fonts || {};
+          const roboto = existingFonts.Roboto || {};
+          const previousPoppins = existingFonts.Poppins || {};
+          const availableFontNames = new Set(validEntries.map(([name]) => name));
+
+          pdfMake.fonts = {
+            ...existingFonts,
+            Poppins: {
+              normal: availableFontNames.has('Poppins-Regular.ttf')
+                ? 'Poppins-Regular.ttf'
+                : previousPoppins.normal || roboto.normal || 'Roboto-Regular.ttf',
+              bold: availableFontNames.has('Poppins-SemiBold.ttf')
+                ? 'Poppins-SemiBold.ttf'
+                : previousPoppins.bold || roboto.bold || 'Roboto-Medium.ttf',
+              italics: availableFontNames.has('Poppins-Italic.ttf')
+                ? 'Poppins-Italic.ttf'
+                : previousPoppins.italics || roboto.italics || 'Roboto-Italic.ttf',
+              bolditalics: availableFontNames.has('Poppins-SemiBoldItalic.ttf')
+                ? 'Poppins-SemiBoldItalic.ttf'
+                : previousPoppins.bolditalics || roboto.bolditalics || 'Roboto-BoldItalic.ttf'
+            }
+          };
+        } catch (error) {
+          console.warn('No se ha podido preparar la tipografía Poppins.', error);
+        }
+      })();
+    }
+
+    try {
+      await poppinsFontPromise;
+    } catch (error) {
+      console.warn('No se ha podido cargar la tipografía Poppins para el certificado.', error);
+    }
   }
 
   function normaliseText(value) {
@@ -126,35 +231,36 @@
   function buildDocStyles() {
     return {
       bodyText: {
-        fontSize: 14,
+        fontSize: 12,
         lineHeight: 1.4
       },
       introText: {
-        fontSize: 14,
-        lineHeight: 1.5,
-        margin: [0, 0, 0, 12]
+        fontSize: 12,
+        lineHeight: 1.45,
+        margin: [0, 0, 0, 10]
       },
       certificateTitle: {
-        fontSize: 34,
+        fontSize: 30,
         bold: true,
         color: '#c4143c',
         letterSpacing: 3,
-        margin: [0, 8, 0, 12]
+        margin: [0, 8, 0, 10]
       },
       highlighted: {
-        fontSize: 16,
+        fontSize: 14,
         bold: true,
         margin: [0, 8, 0, 8]
       },
       trainingName: {
-        fontSize: 20,
+        fontSize: 18,
         bold: true,
-        margin: [0, 16, 0, 0]
+        margin: [0, 14, 0, 0]
       }
     };
   }
 
   async function buildDocDefinition(row) {
+    await ensurePoppinsFont();
     const [backgroundImage, sidebarImage, footerImage, logoImage] = await Promise.all([
       getCachedAsset('background'),
       getCachedAsset('leftSidebar'),
@@ -162,7 +268,7 @@
       getCachedAsset('logo')
     ]);
 
-    const pageMargins = [140, 70, 170, 110];
+    const pageMargins = [105, 40, 160, 100];
     const fullName = buildFullName(row);
     const documentSentence = buildDocumentSentence(row);
     const trainingDate = formatTrainingDate(row.fecha);
@@ -196,29 +302,23 @@
       background: function (currentPage, pageSize) {
         const pageWidth = pageSize.width || 841.89;
         const pageHeight = pageSize.height || 595.28;
-        const sidebarWidth = Math.min(70, pageWidth * 0.08);
+        const baseSidebarWidth = Math.min(70, pageWidth * 0.08);
+        const sidebarWidth = baseSidebarWidth * 0.85;
         const backgroundWidth = Math.min(320, pageWidth * 0.35);
-        const backgroundX = pageWidth - backgroundWidth;
+        const backgroundX = pageWidth - backgroundWidth + backgroundWidth * 0.12;
         const backgroundHeight = backgroundWidth * IMAGE_ASPECT_RATIOS.background;
-        const backgroundY = 0;
-        const backgroundBottom = backgroundY + backgroundHeight;
-        const visibleBackgroundTop = Math.max(0, backgroundY);
-        const visibleBackgroundBottom = Math.min(pageHeight, backgroundBottom);
-        const availableBackgroundHeight = Math.max(
-          0,
-          visibleBackgroundBottom - visibleBackgroundTop
-        );
-        const footerWidth = Math.min(pageWidth - 40, 780);
+        const backgroundY = (pageHeight - backgroundHeight) / 2;
+        const footerBaseWidth = Math.min(pageWidth - 40, 780);
+        const footerMinLeft = Math.max(0, sidebarWidth + 18);
+        const footerMaxWidth = Math.max(0, pageWidth - footerMinLeft - 30);
+        const footerWidth = Math.min(footerBaseWidth * 0.8, footerMaxWidth);
         const footerHeight = footerWidth * IMAGE_ASPECT_RATIOS.footer;
-        const footerX = Math.max(20, (pageWidth - footerWidth) / 2);
-        const footerY = pageHeight - footerHeight;
-        const logoWidth = Math.min(backgroundWidth * 0.7, 220);
+        const bottomLift = pageMargins[3] * 0.1;
+        const footerY = Math.max(0, pageHeight - footerHeight - bottomLift);
+        const logoWidth = Math.min(backgroundWidth * 0.6, 200);
         const logoHeight = logoWidth * IMAGE_ASPECT_RATIOS.logo;
-        const logoYWithinBackground = availableBackgroundHeight
-          ? visibleBackgroundTop + Math.max(0, (availableBackgroundHeight - logoHeight) / 2)
-          : visibleBackgroundTop;
-        const logoY = Math.min(pageHeight - logoHeight, Math.max(0, logoYWithinBackground));
-        const logoX = backgroundX + (backgroundWidth - logoWidth) / 2;
+        const logoY = Math.max(0, (pageHeight - logoHeight) / 2);
+        const logoX = backgroundX + backgroundWidth - logoWidth + Math.min(logoWidth * 0.1, 20);
 
         return [
           {
@@ -240,21 +340,22 @@
           {
             image: footerImage,
             width: footerWidth,
-            absolutePosition: { x: footerX, y: footerY }
+            absolutePosition: { x: footerMinLeft, y: footerY }
           }
         ];
       },
       content: [
         {
-          margin: [0, 40, 0, 0],
+          margin: [0, 12, 0, 0],
           stack: contentStack
         }
       ],
       styles: buildDocStyles(),
       defaultStyle: {
-        fontSize: 14,
-        lineHeight: 1.5,
-        color: '#1f274d'
+        fontSize: 12,
+        lineHeight: 1.45,
+        color: '#1f274d',
+        font: 'Poppins'
       },
       info: {
         title: `Certificado - ${fullName}`,


### PR DESCRIPTION
## Summary
- refine the certificate layout by narrowing the sidebar, repositioning the background artwork, lifting the footer and centering the logo
- reduce text sizing, shift the content block upward and closer to the sidebar, and default the PDF styles to the Poppins typeface with runtime font loading fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd119fe5148328ab161b7ffea41aee