### PR TITLE
Add optional second training date support

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -12,6 +12,7 @@
     { field: 'apellido', label: 'Apellidos', type: 'text', placeholder: 'Apellidos del alumno' },
     { field: 'dni', label: 'DNI / NIE', type: 'text', placeholder: 'Documento' },
     { field: 'fecha', label: 'Fecha', type: 'date' },
+    { field: 'segundaFecha', label: '2ª Fecha', type: 'date' },
     { field: 'lugar', label: 'Lugar', type: 'text', placeholder: 'Sede de la formación' },
     { field: 'duracion', label: 'Duración', type: 'number', placeholder: 'Horas' },
     { field: 'cliente', label: 'Cliente', type: 'text', placeholder: 'Empresa' },
@@ -133,6 +134,7 @@
       dni: '',
       documentType: '',
       fecha: '',
+      segundaFecha: '',
       lugar: '',
       duracion: '',
       cliente: '',
@@ -203,7 +205,7 @@
             input.addEventListener('input', handleValueChange);
           } else {
             input.addEventListener('input', handleValueChange);
-            if (column.field === 'fecha') {
+            if (column.type === 'date') {
               input.addEventListener('change', handleValueChange);
             }
           }
@@ -613,6 +615,7 @@
       ...createEmptyRow(),
       presupuesto: dealId,
       fecha: normaliseDateValue(data.trainingDate),
+      segundaFecha: '',
       lugar: data.trainingLocation || '',
       duracion: getTrainingDuration(data.trainingName),
       cliente: data.clientName || '',

--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -201,6 +201,74 @@
     return formatter.format(parsed);
   }
 
+  function parseDateValue(value) {
+    const normalised = normaliseText(value);
+    if (!normalised) {
+      return null;
+    }
+    const parsed = new Date(normalised);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return parsed;
+  }
+
+  function formatTrainingDateRange(primaryValue, secondaryValue) {
+    const hasSecondary = normaliseText(secondaryValue) !== '';
+    if (!hasSecondary) {
+      return formatTrainingDate(primaryValue);
+    }
+
+    const hasPrimary = normaliseText(primaryValue) !== '';
+    if (!hasPrimary) {
+      return formatTrainingDate(secondaryValue);
+    }
+
+    const primaryDate = parseDateValue(primaryValue);
+    const secondaryDate = parseDateValue(secondaryValue);
+
+    if (primaryDate && secondaryDate) {
+      const sameYear = primaryDate.getFullYear() === secondaryDate.getFullYear();
+      if (sameYear) {
+        const yearFormatter = new Intl.DateTimeFormat('es-ES', { year: 'numeric' });
+        const yearLabel = yearFormatter.format(primaryDate);
+
+        if (primaryDate.getMonth() === secondaryDate.getMonth()) {
+          const dayFormatter = new Intl.DateTimeFormat('es-ES', { day: 'numeric' });
+          const monthFormatter = new Intl.DateTimeFormat('es-ES', { month: 'long' });
+          const firstDay = dayFormatter.format(primaryDate);
+          const secondDay = dayFormatter.format(secondaryDate);
+          const monthLabel = monthFormatter.format(primaryDate);
+          return `${firstDay} y ${secondDay} de ${monthLabel} de ${yearLabel}`;
+        }
+
+        const dayMonthFormatter = new Intl.DateTimeFormat('es-ES', { day: 'numeric', month: 'long' });
+        const firstDayMonth = dayMonthFormatter.format(primaryDate);
+        const secondDayMonth = dayMonthFormatter.format(secondaryDate);
+        return `${firstDayMonth} y ${secondDayMonth} de ${yearLabel}`;
+      }
+
+      const fullFormatter = new Intl.DateTimeFormat('es-ES', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric'
+      });
+      return `${fullFormatter.format(primaryDate)} y ${fullFormatter.format(secondaryDate)}`;
+    }
+
+    const formattedPrimary = formatTrainingDate(primaryValue);
+    const formattedSecondary = formatTrainingDate(secondaryValue);
+
+    if (formattedPrimary === '________') {
+      return formattedSecondary;
+    }
+    if (formattedSecondary === '________') {
+      return formattedPrimary;
+    }
+
+    return `${formattedPrimary} y ${formattedSecondary}`;
+  }
+
   function formatLocation(value) {
     return normaliseText(value) || '________';
   }
@@ -308,7 +376,7 @@
     const pageMargins = [105, 40, 160, 100];
     const fullName = buildFullName(row);
     const documentSentence = buildDocumentSentence(row);
-    const trainingDate = formatTrainingDate(row.fecha);
+    const trainingDate = formatTrainingDateRange(row.fecha, row.segundaFecha);
     const location = formatLocation(row.lugar);
     const duration = formatDuration(row.duracion);
     const trainingName = formatTrainingName(row.formacion);

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,7 @@
                   <th scope="col">Apellidos</th>
                   <th scope="col">DNI / NIE</th>
                   <th scope="col">Fecha</th>
+                  <th scope="col">2ª Fecha</th>
                   <th scope="col">Lugar</th>
                   <th scope="col">Duración (h)</th>
                   <th scope="col">Cliente</th>


### PR DESCRIPTION
## Summary
- add an editable “2ª Fecha” column to the students table and session state
- include the optional second training date when building the certificate text while keeping the original wording when it is empty
- keep deal imports and duration autofill compatible with the new field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd194dca788328aeea7e1bdefce79c