### PR TITLE
Auto-fill second training date for Trabajos Verticales

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -187,27 +187,29 @@
           updateCellTooltip(td, input, column, input.value);
         } else {
           const input = createInput(column, row[column.field], index);
-          input.addEventListener('input', (event) => {
+          const handleValueChange = (event) => {
             const { value } = event.target;
             updateRowValue(index, column.field, value);
             updateCellTooltip(td, input, column, value);
+
             if (column.field === 'formacion') {
-              applyTrainingDuration(index, event.target.value);
+              applyTrainingDuration(index, value);
               applyAutomaticSecondDate(index);
             } else if (column.field === 'fecha') {
               applyAutomaticSecondDate(index);
             }
-          });
-          if (column.type === 'date') {
-            input.addEventListener('change', (event) => {
-              const { value } = event.target;
-              updateRowValue(index, column.field, value);
-              updateCellTooltip(td, input, column, value);
-              if (column.field === 'fecha') {
-                applyAutomaticSecondDate(index);
-              }
-            });
+          };
+
+          if (column.type === 'select') {
+            input.addEventListener('change', handleValueChange);
+            input.addEventListener('input', handleValueChange);
+          } else {
+            input.addEventListener('input', handleValueChange);
+            if (column.type === 'date') {
+              input.addEventListener('change', handleValueChange);
+            }
           }
+
           td.appendChild(input);
           updateCellTooltip(td, input, column, input.value);
         }

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,7 @@
                   <th scope="col">Apellidos</th>
                   <th scope="col">DNI / NIE</th>
                   <th scope="col">Fecha</th>
+                  <th scope="col">2ª Fecha</th>
                   <th scope="col">Lugar</th>
                   <th scope="col">Duración (h)</th>
                   <th scope="col">Cliente</th>


### PR DESCRIPTION
## Summary
- add a "2ª Fecha" column to the students table
- automatically calculate the second training date when the course is Trabajos Verticales
- hydrate and persist the computed date alongside API-loaded data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd175f335c8328833d86572aecda35