### PR TITLE
Rename duration column header to Horas and reduce column width

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -114,6 +114,18 @@ body {
   line-height: 1.3;
 }
 
+.table th.column-hours,
+.table td.column-hours {
+  width: 5rem;
+  min-width: 5rem;
+  max-width: 5rem;
+  white-space: nowrap;
+}
+
+.table td.column-hours .form-control {
+  text-align: center;
+}
+
 .table tbody td .form-control:focus,
 .table tbody td .form-select:focus {
   background-color: rgba(44, 92, 197, 0.08);

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -14,7 +14,7 @@
     { field: 'fecha', label: 'Fecha', type: 'date' },
     { field: 'segundaFecha', label: '2ª Fecha', type: 'date' },
     { field: 'lugar', label: 'Lugar', type: 'text', placeholder: 'Sede de la formación' },
-    { field: 'duracion', label: 'Duración', type: 'number', placeholder: 'Horas' },
+    { field: 'duracion', label: 'Horas', type: 'number', placeholder: 'Horas' },
     { field: 'cliente', label: 'Cliente', type: 'text', placeholder: 'Empresa' },
     { field: 'formacion', label: 'Formación', type: 'text', placeholder: 'Título de la formación' },
     {
@@ -166,6 +166,9 @@
 
       TABLE_COLUMNS.forEach((column) => {
         const td = document.createElement('td');
+        if (column.field === 'duracion') {
+          td.classList.add('column-hours');
+        }
         td.dataset.label = column.label;
 
         if (column.field === 'dni') {

--- a/public/index.html
+++ b/public/index.html
@@ -99,7 +99,7 @@
                   <th scope="col">Fecha</th>
                   <th scope="col">2ª Fecha</th>
                   <th scope="col">Lugar</th>
-                  <th scope="col">Duración (h)</th>
+                  <th scope="col" class="column-hours">Horas</th>
                   <th scope="col">Cliente</th>
                   <th scope="col">Formación</th>
                   <th scope="col">IRATA</th>


### PR DESCRIPTION
## Summary
- rename the duration column to Horas in the table markup and configuration
- narrow the Hours column and center its input so it takes up less space

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd23d93db083288a43f2a98648ba22