### PR TITLE
Use local Poppins font assets

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -1,3 +1,35 @@
+@font-face {
+  font-family: 'Poppins';
+  src: url('../certificados/Poppins-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Poppins';
+  src: url('../certificados/Poppins-Italic.ttf') format('truetype');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Poppins';
+  src: url('../certificados/Poppins-SemiBold.ttf') format('truetype');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Poppins';
+  src: url('../certificados/Poppins-SemiBoldItalic.ttf') format('truetype');
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+
 :root {
   --brand-primary: #2c5cc5;
   --brand-secondary: #f4f6fb;

--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -25,19 +25,19 @@
 
   const FONT_SOURCES = {
     'Poppins-Regular.ttf': [
-      'assets/fonts/poppins/Poppins-Regular.ttf',
+      'assets/certificados/Poppins-Regular.ttf',
       'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-400-normal.ttf'
     ],
     'Poppins-Italic.ttf': [
-      'assets/fonts/poppins/Poppins-Italic.ttf',
+      'assets/certificados/Poppins-Italic.ttf',
       'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-400-italic.ttf'
     ],
     'Poppins-SemiBold.ttf': [
-      'assets/fonts/poppins/Poppins-SemiBold.ttf',
+      'assets/certificados/Poppins-SemiBold.ttf',
       'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-600-normal.ttf'
     ],
     'Poppins-SemiBoldItalic.ttf': [
-      'assets/fonts/poppins/Poppins-SemiBoldItalic.ttf',
+      'assets/certificados/Poppins-SemiBoldItalic.ttf',
       'https://cdn.jsdelivr.net/npm/@fontsource/poppins@5.0.17/files/poppins-latin-600-italic.ttf'
     ]
   };

--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GEP Group · Generador de Certificados</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"


### PR DESCRIPTION
## Summary
- load the Poppins styles from the certificate asset folder for both the UI and generated PDFs
- declare @font-face rules so the app uses the bundled typefaces instead of Google Fonts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd28782b1c8328a69565c5edfc10b7