### PR TITLE
Ajusta ancho de columna DNI para ampliar apellidos

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -217,14 +217,15 @@ body {
 .table tbody td .document-wrapper {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  width: 100%;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  width: auto;
 }
 
 .table tbody td .document-wrapper .form-control {
-  flex: 1 1 10ch;
-  min-width: 10ch;
-  width: 100%;
+  flex: 0 0 auto;
+  min-width: 0;
+  width: 9ch;
 }
 
 .document-badge {
@@ -238,7 +239,9 @@ body {
 
 #students-table th:nth-child(4),
 #students-table td[data-label='DNI / NIE'] {
-  min-width: 10ch;
+  min-width: 0;
+  width: 1%;
+  white-space: nowrap;
 }
 
 #students-table th:nth-child(5),


### PR DESCRIPTION
## Summary
- reduce el ancho mínimo de la columna de DNI / NIE para dar más espacio al campo de apellidos
- alinea el contenido del documento hacia la derecha y reduce el espacio interno del contenedor para acercarlo a las fechas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2c23eda4832884a5573e77dcbd6c