### PR TITLE
Handle secondary training dates for budgets

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -618,7 +618,7 @@
       ...createEmptyRow(),
       presupuesto: dealId,
       fecha: normaliseDateValue(data.trainingDate),
-      segundaFecha: '',
+      segundaFecha: normaliseDateValue(data.secondaryTrainingDate),
       lugar: data.trainingLocation || '',
       duracion: getTrainingDuration(data.trainingName),
       cliente: data.clientName || '',


### PR DESCRIPTION
## Summary
- normalise training date values from Pipedrive deals and extract optional secondary dates
- return the secondary training date in the fetch-deal response alongside the primary date
- autofill the second date column in the table with the fetched secondary training date

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3118761c8328a59c9ca04f15d3f8