### PR TITLE
Add training template management modal and shared template store

### DIFF
--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -47,141 +47,7 @@
   let poppinsFontPromise = null;
 
   const assetCache = new Map();
-
-  function normaliseTrainingName(value) {
-    if (value === undefined || value === null) {
-      return '';
-    }
-    return String(value)
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .replace(/[^a-z0-9]+/g, ' ')
-      .trim()
-      .replace(/\s+/g, ' ');
-  }
-
-  function normaliseDetailItems(items) {
-    if (!Array.isArray(items)) {
-      return [];
-    }
-    return items
-      .map((item) => {
-        if (item === undefined || item === null) {
-          return '';
-        }
-        return String(item).trim();
-      })
-      .filter((text) => text !== '');
-  }
-
-  function normaliseTrainingDetails(details) {
-    if (!details || typeof details !== 'object') {
-      return { theory: [], practice: [] };
-    }
-    return {
-      theory: normaliseDetailItems(details.theory),
-      practice: normaliseDetailItems(details.practice)
-    };
-  }
-
-  const TRAINING_DETAILS_ENTRIES = [
-    [
-      'Pack Emergencias - Extinción de incendios básico y primeros auxilios',
-      {
-        theory: [
-          'Proceso de la combustión.',
-          'Clases de fuego.',
-          'Clasificación de combustible.',
-          'Propagación de un incendio.',
-          'Transferencia de calor.',
-          'Agentes extintores.',
-          'Mecanismos de extinción.',
-          'Protocolo de actuación (P.A.S.).',
-          'Valoración primaria.',
-          'Posiciones de espera y traslado (P.L.S.).',
-          'O.V.A.C.E. obstrucción vía aérea (Maniobra de Heimlich).'
-        ],
-        practice: [
-          'Reconocer diferentes tipos de extintores.',
-          'Trabajo en interior con extintor de polvo.',
-          'Extinción con CO₂ en armario eléctrico.',
-          'Extinción y cubrimiento con extintor hídrico.',
-          'Ejercicio/simulacro con diferentes grados de dificultad, corte de suministro, víctima consciente e inconsciente.',
-          'Apertura de puertas y comprobación de temperatura.'
-        ]
-      }
-    ],
-    [
-      'Trabajos en Altura',
-      {
-        theory: [
-          'Legislación y normativa vigente.',
-          'Medidas de protección preventiva.',
-          'Conocimientos generales de seguridad en altura.',
-          'Equipos de protección individual y colectiva.',
-          'Instalaciones horizontales y verticales.',
-          'Actuación en caso de emergencia.'
-        ],
-        practice: [
-          'Los nudos básicos y su realización.',
-          'Utilización de equipos de protección individual.',
-          'Utilización de los equipos de protección colectiva.',
-          'Instalación de líneas de vida horizontales y verticales.',
-          'Puntos de anclaje.',
-          'Técnicas de acceso y posicionamiento en altura.',
-          'Rescate de emergencia.'
-        ]
-      }
-    ],
-    [
-      'Trabajos Verticales',
-      {
-        theory: [
-          'Legislación y normativa vigente.',
-          'Medidas de protección preventiva.',
-          'Procedimientos de actuación y rescate.',
-          'Conocimientos generales sobre seguridad.',
-          'Equipos de protección individual y colectiva.',
-          'Sistemas de instalación vertical y horizontal.',
-          'Actuación en caso de emergencia y protocolo P.A.S.'
-        ],
-        practice: [
-          'Taller de nudos y anclajes.',
-          'Utilización y pruebas con los equipos de protección individual.',
-          'Montaje de instalaciones verticales.',
-          'Protección de las instalaciones.',
-          'Paso de nudos.',
-          'Ascenso y descenso con cuerdas, paso de nudos y cambios de cuerda.',
-          'Rescate de víctimas y evacuación segura.'
-        ]
-      }
-    ]
-  ];
-
-  const TRAINING_DETAILS_LOOKUP = TRAINING_DETAILS_ENTRIES.reduce((lookup, [name, details]) => {
-    const key = normaliseTrainingName(name);
-    if (!key || lookup.has(key)) {
-      return lookup;
-    }
-    lookup.set(key, normaliseTrainingDetails(details));
-    return lookup;
-  }, new Map());
-
-  function getTrainingDetails(trainingName) {
-    const key = normaliseTrainingName(trainingName);
-    if (!key) {
-      return null;
-    }
-    const details = TRAINING_DETAILS_LOOKUP.get(key);
-    if (!details) {
-      return null;
-    }
-    return {
-      theory: [...details.theory],
-      practice: [...details.practice]
-    };
-  }
+  const trainingTemplates = global.trainingTemplates || null;
 
   function buildTrainingDetailsContent(details) {
     if (!details) {
@@ -585,8 +451,13 @@
     const trainingDate = formatTrainingDateRange(row.fecha, row.segundaFecha);
     const location = formatLocation(row.lugar);
     const duration = formatDuration(row.duracion);
-    const trainingName = formatTrainingName(row.formacion);
-    const trainingDetails = getTrainingDetails(row.formacion);
+    const trainingTitle = trainingTemplates
+      ? trainingTemplates.getTrainingTitle(row.formacion)
+      : row.formacion;
+    const trainingName = formatTrainingName(trainingTitle);
+    const trainingDetails = trainingTemplates
+      ? trainingTemplates.getTrainingDetails(row.formacion)
+      : null;
     const pageWidth = PAGE_DIMENSIONS.width;
     const pageHeight = PAGE_DIMENSIONS.height;
     const footerGeometry = calculateFooterGeometry(pageWidth, pageHeight, pageMargins);

--- a/public/assets/js/training-templates.js
+++ b/public/assets/js/training-templates.js
@@ -1,0 +1,487 @@
+(function (global) {
+  const STORAGE_KEY = 'gep-certificados/training-templates/v1';
+
+  const DEFAULT_DURATION_ENTRIES = [
+    ['Pack Emergencias', '6h'],
+    ['Trabajos en Altura', '8h'],
+    ['Trabajos Verticales', '12h'],
+    ['Carretilla elevadora', '8h'],
+    ['Espacios Confinados', '8h'],
+    ['Operaciones Telco', '6h'],
+    ['Riesgo Eléctrico Telco', '6h'],
+    ['Espacios Confinados Telco', '6h'],
+    ['Trabajos en altura Telco', '6h'],
+    ['Basico de Fuego', '4h'],
+    ['Avanzado de Fuego', '5h'],
+    ['Avanzado y Casa de Humo', '6h'],
+    ['Riesgo Químico', '4h'],
+    ['Primeros Auxilios', '4h'],
+    ['SVD y DEA', '6h'],
+    ['Implantación de PAU', '6h'],
+    ['Jefes de Emergencias', '8h'],
+    ["Curso de ERA's", '8h'],
+    ['Andamios', '8h'],
+    ['Renovación Bombero de Empresa', '20h'],
+    ['Bombero de Empresa Inicial', '350h']
+  ];
+
+  const DEFAULT_DETAILS_ENTRIES = [
+    [
+      'Pack Emergencias - Extinción de incendios básico y primeros auxilios',
+      {
+        theory: [
+          'Proceso de la combustión.',
+          'Clases de fuego.',
+          'Clasificación de combustible.',
+          'Propagación de un incendio.',
+          'Transferencia de calor.',
+          'Agentes extintores.',
+          'Mecanismos de extinción.',
+          'Protocolo de actuación (P.A.S.).',
+          'Valoración primaria.',
+          'Posiciones de espera y traslado (P.L.S.).',
+          'O.V.A.C.E. obstrucción vía aérea (Maniobra de Heimlich).'
+        ],
+        practice: [
+          'Reconocer diferentes tipos de extintores.',
+          'Trabajo en interior con extintor de polvo.',
+          'Extinción con CO₂ en armario eléctrico.',
+          'Extinción y cubrimiento con extintor hídrico.',
+          'Ejercicio/simulacro con diferentes grados de dificultad, corte de suministro, víctima consciente e inconsciente.',
+          'Apertura de puertas y comprobación de temperatura.'
+        ]
+      }
+    ],
+    [
+      'Trabajos en Altura',
+      {
+        theory: [
+          'Legislación y normativa vigente.',
+          'Medidas de protección preventiva.',
+          'Conocimientos generales de seguridad en altura.',
+          'Equipos de protección individual y colectiva.',
+          'Instalaciones horizontales y verticales.',
+          'Actuación en caso de emergencia.'
+        ],
+        practice: [
+          'Los nudos básicos y su realización.',
+          'Utilización de equipos de protección individual.',
+          'Utilización de los equipos de protección colectiva.',
+          'Instalación de líneas de vida horizontales y verticales.',
+          'Puntos de anclaje.',
+          'Técnicas de acceso y posicionamiento en altura.',
+          'Rescate de emergencia.'
+        ]
+      }
+    ],
+    [
+      'Trabajos Verticales',
+      {
+        theory: [
+          'Legislación y normativa vigente.',
+          'Medidas de protección preventiva.',
+          'Procedimientos de actuación y rescate.',
+          'Conocimientos generales sobre seguridad.',
+          'Equipos de protección individual y colectiva.',
+          'Sistemas de instalación vertical y horizontal.',
+          'Actuación en caso de emergencia y protocolo P.A.S.'
+        ],
+        practice: [
+          'Taller de nudos y anclajes.',
+          'Utilización y pruebas con los equipos de protección individual.',
+          'Montaje de instalaciones verticales.',
+          'Protección de las instalaciones.',
+          'Paso de nudos.',
+          'Ascenso y descenso con cuerdas, paso de nudos y cambios de cuerda.',
+          'Rescate de víctimas y evacuación segura.'
+        ]
+      }
+    ]
+  ];
+
+  function normaliseName(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return String(value)
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim()
+      .replace(/\s+/g, ' ');
+  }
+
+  function sanitiseText(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function sanitiseList(items) {
+    if (!Array.isArray(items)) {
+      return [];
+    }
+    return items
+      .map((item) => sanitiseText(item))
+      .filter((text) => text !== '');
+  }
+
+  function cloneTemplate(template) {
+    if (!template) {
+      return null;
+    }
+    return {
+      id: template.id,
+      name: template.name,
+      title: template.title,
+      duration: template.duration,
+      theory: [...template.theory],
+      practice: [...template.practice]
+    };
+  }
+
+  function createCustomId() {
+    return `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function sanitiseTemplate(template) {
+    if (!template || typeof template !== 'object') {
+      return {
+        id: '',
+        name: '',
+        title: '',
+        duration: '',
+        theory: [],
+        practice: []
+      };
+    }
+
+    const name = sanitiseText(template.name);
+    const title = sanitiseText(template.title) || name;
+
+    return {
+      id: template.id ? String(template.id) : '',
+      name,
+      title,
+      duration: sanitiseText(template.duration),
+      theory: sanitiseList(template.theory),
+      practice: sanitiseList(template.practice)
+    };
+  }
+
+  function buildDefaultTemplates() {
+    const templatesByName = new Map();
+    const durationLookup = new Map();
+
+    DEFAULT_DURATION_ENTRIES.forEach(([name, duration]) => {
+      const normalisedName = normaliseName(name);
+      if (!normalisedName) {
+        return;
+      }
+      const sanitisedDuration = sanitiseText(duration);
+      if (sanitisedDuration) {
+        durationLookup.set(normalisedName, sanitisedDuration);
+      }
+      const existing = templatesByName.get(normalisedName) || {
+        id: `default-${normalisedName}`,
+        name: sanitiseText(name),
+        title: sanitiseText(name),
+        duration: '',
+        theory: [],
+        practice: []
+      };
+      existing.duration = sanitisedDuration;
+      templatesByName.set(normalisedName, existing);
+    });
+
+    DEFAULT_DETAILS_ENTRIES.forEach(([name, details]) => {
+      const normalisedName = normaliseName(name);
+      if (!normalisedName) {
+        return;
+      }
+      const existing = templatesByName.get(normalisedName) || {
+        id: `default-${normalisedName}`,
+        name: sanitiseText(name),
+        title: sanitiseText(name),
+        duration: '',
+        theory: [],
+        practice: []
+      };
+      existing.name = sanitiseText(name) || existing.name;
+      existing.title = sanitiseText(details && details.title) || existing.name || existing.title;
+      existing.theory = sanitiseList(details && details.theory);
+      existing.practice = sanitiseList(details && details.practice);
+      if (!existing.duration) {
+        let matchedDuration = durationLookup.get(normalisedName) || '';
+        if (!matchedDuration) {
+          for (const [durationKey, durationValue] of durationLookup.entries()) {
+            if (durationKey && normalisedName.startsWith(durationKey)) {
+              matchedDuration = durationValue;
+              break;
+            }
+          }
+        }
+        if (matchedDuration) {
+          existing.duration = matchedDuration;
+        }
+      }
+      templatesByName.set(normalisedName, existing);
+    });
+
+    return Array.from(templatesByName.entries()).map(([key, template]) => {
+      const sanitised = sanitiseTemplate(template);
+      sanitised.id = template.id || `default-${key}`;
+      if (!sanitised.title) {
+        sanitised.title = sanitised.name;
+      }
+      return sanitised;
+    });
+  }
+
+  function mergeTemplates(defaultTemplates, customTemplates) {
+    const templatesByName = new Map();
+
+    defaultTemplates.forEach((template) => {
+      const normalisedName = normaliseName(template.name);
+      if (!normalisedName) {
+        return;
+      }
+      templatesByName.set(normalisedName, {
+        ...template,
+        id: template.id || `default-${normalisedName}`,
+        theory: [...template.theory],
+        practice: [...template.practice]
+      });
+    });
+
+    customTemplates.forEach((template) => {
+      const sanitised = sanitiseTemplate(template);
+      const normalisedName = normaliseName(sanitised.name);
+      if (!normalisedName) {
+        return;
+      }
+      const customId = sanitised.id || createCustomId();
+      templatesByName.set(normalisedName, {
+        ...sanitised,
+        id: customId,
+        theory: [...sanitised.theory],
+        practice: [...sanitised.practice]
+      });
+    });
+
+    return Array.from(templatesByName.values());
+  }
+
+  function loadCustomTemplates() {
+    try {
+      if (!global.localStorage) {
+        return [];
+      }
+      const raw = global.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.map((template) => {
+        const sanitised = sanitiseTemplate(template);
+        if (!sanitised.id) {
+          sanitised.id = createCustomId();
+        }
+        if (!sanitised.title) {
+          sanitised.title = sanitised.name;
+        }
+        return sanitised;
+      });
+    } catch (error) {
+      console.warn('No se han podido cargar las plantillas personalizadas', error);
+      return [];
+    }
+  }
+
+  function persistCustomTemplates(customTemplates) {
+    try {
+      if (!global.localStorage) {
+        return;
+      }
+      const serialisable = customTemplates.map((template) => ({
+        id: template.id,
+        name: template.name,
+        title: template.title,
+        duration: template.duration,
+        theory: [...template.theory],
+        practice: [...template.practice]
+      }));
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(serialisable));
+    } catch (error) {
+      console.warn('No se han podido guardar las plantillas personalizadas', error);
+    }
+  }
+
+  let customTemplates = loadCustomTemplates();
+  let templates = [];
+  let sortedTemplates = [];
+  let templatesByName = new Map();
+  let templatesById = new Map();
+  const subscribers = new Set();
+
+  function refreshTemplates() {
+    const defaultTemplates = buildDefaultTemplates();
+    templates = mergeTemplates(defaultTemplates, customTemplates);
+
+    templatesByName = new Map();
+    templatesById = new Map();
+
+    templates.forEach((template) => {
+      const normalisedName = normaliseName(template.name);
+      const id = template.id ? String(template.id) : '';
+      if (normalisedName) {
+        templatesByName.set(normalisedName, template);
+      }
+      if (id) {
+        templatesById.set(id, template);
+      }
+    });
+
+    sortedTemplates = templates
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }));
+  }
+
+  function notifySubscribers() {
+    subscribers.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.error('Error al notificar los cambios de plantillas', error);
+      }
+    });
+  }
+
+  refreshTemplates();
+
+  function listTemplates() {
+    return sortedTemplates.map((template) => cloneTemplate(template));
+  }
+
+  function getTemplateByName(name) {
+    const normalisedName = normaliseName(name);
+    if (!normalisedName) {
+      return null;
+    }
+    const template = templatesByName.get(normalisedName);
+    return cloneTemplate(template);
+  }
+
+  function getTemplateById(id) {
+    if (!id) {
+      return null;
+    }
+    const template = templatesById.get(String(id));
+    return cloneTemplate(template);
+  }
+
+  function getTrainingDuration(name) {
+    const template = getTemplateByName(name);
+    return template ? template.duration : '';
+  }
+
+  function getTrainingDetails(name) {
+    const template = getTemplateByName(name);
+    if (!template) {
+      return null;
+    }
+    return {
+      theory: [...template.theory],
+      practice: [...template.practice]
+    };
+  }
+
+  function getTrainingTitle(name) {
+    const template = getTemplateByName(name);
+    if (!template) {
+      return sanitiseText(name);
+    }
+    return template.title || template.name;
+  }
+
+  function saveTemplate(template) {
+    const sanitised = sanitiseTemplate(template);
+    if (!sanitised.name) {
+      throw new Error('El nombre de la formación es obligatorio.');
+    }
+    if (!sanitised.title) {
+      sanitised.title = sanitised.name;
+    }
+    const normalisedName = normaliseName(sanitised.name);
+    if (!normalisedName) {
+      throw new Error('El nombre de la formación es obligatorio.');
+    }
+
+    if (!sanitised.id) {
+      const existing = customTemplates.find((item) => normaliseName(item.name) === normalisedName);
+      sanitised.id = existing ? existing.id : createCustomId();
+    }
+
+    let stored = false;
+    customTemplates = customTemplates.map((item) => {
+      if (item.id === sanitised.id) {
+        stored = true;
+        return { ...sanitised };
+      }
+      if (normaliseName(item.name) === normalisedName) {
+        stored = true;
+        return { ...sanitised, id: item.id };
+      }
+      return item;
+    });
+
+    if (!stored) {
+      customTemplates.push({ ...sanitised });
+    }
+
+    persistCustomTemplates(customTemplates);
+    refreshTemplates();
+    notifySubscribers();
+
+    return getTemplateById(sanitised.id) || getTemplateByName(sanitised.name);
+  }
+
+  function createEmptyTemplate() {
+    return {
+      id: '',
+      name: '',
+      title: '',
+      duration: '',
+      theory: [],
+      practice: []
+    };
+  }
+
+  function subscribe(callback) {
+    if (typeof callback !== 'function') {
+      return () => {};
+    }
+    subscribers.add(callback);
+    return () => {
+      subscribers.delete(callback);
+    };
+  }
+
+  global.trainingTemplates = {
+    listTemplates,
+    getTemplateByName,
+    getTemplateById,
+    getTrainingDuration,
+    getTrainingDetails,
+    getTrainingTitle,
+    saveTemplate,
+    createEmptyTemplate,
+    subscribe,
+    normaliseName
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/public/index.html
+++ b/public/index.html
@@ -50,14 +50,25 @@
                   />
                 </div>
                 <div class="col-lg-4">
-                  <button
-                    type="submit"
-                    class="btn btn-primary w-100 d-flex align-items-center justify-content-center gap-2"
-                    id="fill-button"
-                  >
-                    <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
-                    <span class="button-text">Añadir alumn@/s</span>
-                  </button>
+                  <div class="d-flex flex-column flex-sm-row gap-2">
+                    <button
+                      type="submit"
+                      class="btn btn-primary flex-fill d-flex align-items-center justify-content-center gap-2"
+                      id="fill-button"
+                    >
+                      <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                      <span class="button-text">Añadir alumn@/s</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-outline-primary flex-fill"
+                      id="manage-templates-button"
+                      data-bs-toggle="modal"
+                      data-bs-target="#training-templates-modal"
+                    >
+                      Modificar Plantillas
+                    </button>
+                  </div>
                 </div>
               </form>
             </div>
@@ -107,6 +118,94 @@
       </section>
     </main>
 
+    <div
+      class="modal fade"
+      id="training-templates-modal"
+      tabindex="-1"
+      aria-labelledby="training-templates-modal-label"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-scrollable modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="training-templates-modal-label">
+              Modificar plantillas de formación
+            </h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <form id="training-template-form" class="vstack gap-3">
+              <div>
+                <label for="template-selector" class="form-label">Plantilla disponible</label>
+                <select id="template-selector" class="form-select" aria-describedby="template-selector-help">
+                  <option value="" selected disabled>Selecciona una plantilla…</option>
+                </select>
+                <div id="template-selector-help" class="form-text">
+                  Elige una plantilla existente o selecciona "Crear nueva plantilla" para empezar desde cero.
+                </div>
+              </div>
+              <div class="row g-3">
+                <div class="col-lg-6">
+                  <label for="template-name" class="form-label">Nombre de la formación</label>
+                  <input
+                    type="text"
+                    id="template-name"
+                    class="form-control"
+                    placeholder="Nombre interno de la formación"
+                    required
+                  />
+                </div>
+                <div class="col-lg-6">
+                  <label for="template-title" class="form-label">Título de la formación</label>
+                  <input
+                    type="text"
+                    id="template-title"
+                    class="form-control"
+                    placeholder="Título que aparecerá en el certificado"
+                    required
+                  />
+                  <div class="form-text">Este título se utilizará en el PDF del certificado.</div>
+                </div>
+              </div>
+              <div>
+                <label for="template-duration" class="form-label">Duración de la formación</label>
+                <input
+                  type="text"
+                  id="template-duration"
+                  class="form-control"
+                  placeholder="Por ejemplo: 8h"
+                />
+              </div>
+              <div class="row g-4">
+                <div class="col-lg-6">
+                  <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h2 class="h6 mb-0">Parte teórica</h2>
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="add-theory-point">
+                      Añadir punto
+                    </button>
+                  </div>
+                  <div id="theory-list" class="vstack gap-2"></div>
+                </div>
+                <div class="col-lg-6">
+                  <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h2 class="h6 mb-0">Parte práctica</h2>
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="add-practice-point">
+                      Añadir punto
+                    </button>
+                  </div>
+                  <div id="practice-list" class="vstack gap-2"></div>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cerrar</button>
+            <button type="submit" form="training-template-form" class="btn btn-primary">Guardar plantilla</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
@@ -114,6 +213,7 @@
     ></script>
     <script defer src="https://cdn.jsdelivr.net/npm/pdfmake@0.2.7/build/pdfmake.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/pdfmake@0.2.7/build/vfs_fonts.js"></script>
+    <script src="assets/js/training-templates.js" defer></script>
     <script src="assets/js/certificate-pdf.js" defer></script>
     <script src="assets/js/brand-assets.js" defer></script>
     <script src="assets/js/app.js" defer></script>


### PR DESCRIPTION
## Summary
- add a "Modificar Plantillas" button and modal that lets users manage training templates alongside the budget form
- create a shared training-templates module that persists durations, titles, and theory/practice items with local storage
- update the app and PDF generator to consume the editable template data, including the new training title field

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cd37af15a48328b00e4b3cdd6dbf5d