### PR TITLE
Reduce theory bullet font size in certificate PDF

### DIFF
--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -64,7 +64,7 @@
         stack: [
           { text: 'Parte teórica', style: 'sectionHeading' },
           {
-            ul: theoryItems.map((item) => ({ text: item, style: 'listItem' })),
+            ul: theoryItems.map((item) => ({ text: item, style: 'theoryListItem' })),
             margin: [0, 2, 0, 0]
           }
         ]
@@ -455,6 +455,11 @@
         margin: [0, 0, 0, 4]
       },
       listItem: {
+        margin: [0, 0, 0, 3]
+      },
+      theoryListItem: {
+        fontSize: 9,
+        lineHeight: 1.2,
         margin: [0, 0, 0, 3]
       }
     };


### PR DESCRIPTION
## Summary
- adjust the PDF generation to use a dedicated style for theory list items
- define a smaller font size and tighter line-height for theory bullet points so they fit on one page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd40a37bc08328b1a48d87cc808684