### PR TITLE
Mostrar siempre el botón de eliminar plantilla personalizada

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -373,7 +373,15 @@
     );
 
     deleteTemplateButton.disabled = !canDelete;
-    deleteTemplateButton.classList.toggle('d-none', !canDelete);
+    deleteTemplateButton.setAttribute('aria-disabled', String(!canDelete));
+    if (canDelete) {
+      deleteTemplateButton.removeAttribute('title');
+    } else {
+      deleteTemplateButton.setAttribute(
+        'title',
+        'Solo se pueden eliminar las plantillas personalizadas.'
+      );
+    }
   }
 
   function handleDeleteTemplateClick() {

--- a/public/index.html
+++ b/public/index.html
@@ -199,7 +199,12 @@
             </form>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-outline-danger me-auto d-none" id="delete-template-button">
+            <button
+              type="button"
+              class="btn btn-outline-danger me-auto"
+              id="delete-template-button"
+              disabled
+            >
               Eliminar plantilla
             </button>
             <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cerrar</button>


### PR DESCRIPTION
## Summary
- mantener visible el botón de eliminar plantilla dentro del modal de gestión
- deshabilitar el botón cuando no sea posible eliminar y mostrar un mensaje explicativo

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd47e96fd8832897884056f451d574