### PR TITLE
Reduce footer image size by 15%

### DIFF
--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -16,7 +16,7 @@
   };
 
   const SIDEBAR_WIDTH_REDUCTION = 0.55;
-  const FOOTER_WIDTH_REDUCTION = 0.96;
+  const FOOTER_WIDTH_REDUCTION = 0.816; // 15% size reduction applied to previous value
   const FOOTER_LEFT_ADDITIONAL_OFFSET = 20;
   const FOOTER_BASELINE_PADDING = 18;
   const BACKGROUND_MARGIN_BLEED = 20;


### PR DESCRIPTION
## Summary
- decrease the footer image scaling factor used when generating certificates
- keep the footer origin aligned by only shrinking the proportional width of the image

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd52b9243883288276c76c9c8f7ef2