### PR TITLE
Restore duration autofill for training rows

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -16,7 +16,7 @@
     { field: 'fecha', label: 'Fecha', type: 'date' },
     { field: 'segundaFecha', label: '2ª Fecha', type: 'date' },
     { field: 'lugar', label: 'Lugar', type: 'text', placeholder: 'Sede de la formación' },
-    { field: 'duracion', label: 'Horas', type: 'number', placeholder: 'Horas' },
+    { field: 'duracion', label: 'Horas', type: 'text', placeholder: 'Ej. 6h' },
     { field: 'cliente', label: 'Cliente', type: 'text', placeholder: 'Empresa' },
     { field: 'formacion', label: 'Formación', type: 'text', placeholder: 'Título de la formación' },
     {
@@ -733,7 +733,12 @@
     if (column.label) {
       input.setAttribute('aria-label', column.label);
     }
-    if (column.type === 'number') {
+    if (column.field === 'duracion') {
+      input.autocomplete = 'off';
+      input.inputMode = 'decimal';
+      input.pattern = '^\\d+(?:[.,]\\d{1,2})?h?$';
+      input.spellcheck = false;
+    } else if (column.type === 'number') {
       input.min = '0';
       input.step = '0.5';
       input.inputMode = 'decimal';


### PR DESCRIPTION
## Summary
- allow the hours column to accept formatted values such as "6h" so template durations populate correctly
- configure the duration input to favour numeric entry while keeping manual overrides for certificates

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cd61f7a9608328bf9b07ec043e356b