### PR TITLE
Añadir carga de documentos de alumnado con análisis de OpenAI

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -1,0 +1,442 @@
+const HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS'
+};
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const SUPPORTED_MIME_TYPES = new Set([
+  'application/pdf',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'text/csv',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/bmp',
+  'image/tiff',
+  'image/heic',
+  'image/heif'
+]);
+
+const EXTENSION_MIME_MAP = {
+  pdf: 'application/pdf',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  csv: 'text/csv',
+  ods: 'application/vnd.oasis.opendocument.spreadsheet',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  bmp: 'image/bmp',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  heic: 'image/heic',
+  heif: 'image/heif'
+};
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: HEADERS,
+      body: ''
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { success: false, message: 'Método no permitido.' });
+  }
+
+  let payload = null;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch (error) {
+    return jsonResponse(400, { success: false, message: 'El cuerpo de la solicitud no es válido.' });
+  }
+
+  const budgetId = normaliseText(payload?.budgetId);
+  const fileName = normaliseFileName(payload?.fileName);
+  const fileType = normaliseText(payload?.fileType).toLowerCase();
+  const fileSize = Number(payload?.fileSize) || 0;
+  const fileData = typeof payload?.fileData === 'string' ? payload.fileData : '';
+
+  if (!budgetId) {
+    return jsonResponse(400, { success: false, message: 'Debes indicar el número de presupuesto.' });
+  }
+
+  if (!fileName || !fileData) {
+    return jsonResponse(400, {
+      success: false,
+      message: 'Debes adjuntar un archivo en formato PDF, Excel o imagen.'
+    });
+  }
+
+  const buffer = decodeBase64File(fileData);
+  if (!buffer || !buffer.length) {
+    return jsonResponse(400, { success: false, message: 'El archivo recibido no es válido.' });
+  }
+
+  if (buffer.length > MAX_FILE_SIZE || fileSize > MAX_FILE_SIZE) {
+    return jsonResponse(413, {
+      success: false,
+      message: 'El archivo supera el tamaño máximo permitido (10 MB).'
+    });
+  }
+
+  const { valid, mimeType, message: validationMessage } = resolveFileMimeType(fileName, fileType);
+  if (!valid) {
+    return jsonResponse(400, {
+      success: false,
+      message: validationMessage || 'El tipo de archivo no es compatible. Usa un PDF, Excel o imagen.'
+    });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return jsonResponse(500, {
+      success: false,
+      message: 'Falta configurar la variable de entorno OPENAI_API_KEY en Netlify.'
+    });
+  }
+
+  const authorisationHeader = `Bearer ${apiKey}`;
+  let uploadedFileId = '';
+
+  try {
+    uploadedFileId = await uploadFileToOpenAi(buffer, fileName, mimeType, authorisationHeader);
+    const responsePayload = await requestOpenAiExtraction(uploadedFileId, authorisationHeader);
+    const outputText = extractResponseText(responsePayload);
+    const parsed = parseResponsePayload(outputText);
+    const students = normaliseStudents(parsed.students);
+    const warnings = normaliseWarnings(parsed.warnings);
+
+    return jsonResponse(200, {
+      success: true,
+      data: {
+        students,
+        warnings
+      }
+    });
+  } catch (error) {
+    console.error('Error procesando el documento con OpenAI', error);
+    const status = error?.status && Number.isInteger(error.status) ? error.status : 500;
+    const message = translateOpenAiError(error);
+    return jsonResponse(status, { success: false, message });
+  } finally {
+    if (uploadedFileId) {
+      try {
+        await fetch(`https://api.openai.com/v1/files/${encodeURIComponent(uploadedFileId)}`, {
+          method: 'DELETE',
+          headers: {
+            Authorization: authorisationHeader
+          }
+        });
+      } catch (cleanupError) {
+        console.warn('No se ha podido eliminar el archivo temporal de OpenAI', cleanupError);
+      }
+    }
+  }
+};
+
+async function uploadFileToOpenAi(buffer, fileName, mimeType, authorisationHeader) {
+  const formData = new FormData();
+  formData.append('purpose', 'assistants');
+  formData.append('file', new File([buffer], fileName, { type: mimeType || 'application/octet-stream' }));
+
+  const response = await fetch('https://api.openai.com/v1/files', {
+    method: 'POST',
+    headers: {
+      Authorization: authorisationHeader
+    },
+    body: formData
+  });
+
+  const payload = await safeJson(response);
+
+  if (!response.ok || !payload?.id) {
+    const error = buildOpenAiError(response.status, payload);
+    throw error;
+  }
+
+  return payload.id;
+}
+
+async function requestOpenAiExtraction(fileId, authorisationHeader) {
+  const body = {
+    model: 'gpt-4.1-mini',
+    temperature: 0,
+    input: [
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text:
+              'Eres un asistente que ayuda a un equipo de formación a extraer listados de alumnado. '
+              + 'Cuando recibas un documento deberás identificar a todos los alumnos y alumnas, '
+              + 'separar el nombre de los apellidos y recuperar su DNI o NIE si está disponible. '
+              + 'Si algún dato no aparece, devuelve el campo vacío.'
+          }
+        ]
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_text',
+            text:
+              'Analiza el archivo adjunto y devuelve un JSON con el listado de alumnos. '
+              + 'Cada elemento debe incluir "nombre", "apellido" y "dni". '
+              + 'Si detectas dudas o incidencias importantes añádelas en un campo "warnings".'
+          },
+          {
+            type: 'input_file',
+            file_id: fileId
+          }
+        ]
+      }
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'students_payload',
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            students: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  nombre: { type: 'string', description: 'Nombre de pila del alumno o alumna.' },
+                  apellido: { type: 'string', description: 'Apellidos del alumno o alumna.' },
+                  dni: { type: 'string', description: 'Documento identificativo (DNI, NIE, etc.).' }
+                },
+                required: ['nombre', 'apellido', 'dni']
+              }
+            },
+            warnings: {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          },
+          required: ['students']
+        },
+        strict: true
+      }
+    }
+  };
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: authorisationHeader,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+
+  const payload = await safeJson(response);
+
+  if (!response.ok) {
+    const error = buildOpenAiError(response.status, payload);
+    throw error;
+  }
+
+  return payload;
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: HEADERS,
+    body: JSON.stringify(body)
+  };
+}
+
+function decodeBase64File(data) {
+  if (!data) {
+    return null;
+  }
+
+  const normalised = data.includes('base64,') ? data.slice(data.indexOf('base64,') + 7) : data;
+
+  try {
+    return Buffer.from(normalised, 'base64');
+  } catch (error) {
+    return null;
+  }
+}
+
+function resolveFileMimeType(fileName, providedMime) {
+  const mime = providedMime && SUPPORTED_MIME_TYPES.has(providedMime) ? providedMime : '';
+  if (mime) {
+    return { valid: true, mimeType: mime };
+  }
+
+  const extension = extractExtension(fileName);
+  if (extension && EXTENSION_MIME_MAP[extension]) {
+    return {
+      valid: true,
+      mimeType: EXTENSION_MIME_MAP[extension]
+    };
+  }
+
+  return {
+    valid: false,
+    mimeType: '',
+    message: 'El tipo de archivo no es compatible. Usa un PDF, Excel o imagen.'
+  };
+}
+
+function extractExtension(fileName = '') {
+  const normalised = normaliseText(fileName).toLowerCase();
+  const lastDot = normalised.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === normalised.length - 1) {
+    return '';
+  }
+  return normalised.slice(lastDot + 1);
+}
+
+function parseResponsePayload(text) {
+  if (!text) {
+    return { students: [], warnings: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('No se ha podido interpretar la respuesta de OpenAI como JSON.', error);
+  }
+
+  return { students: [], warnings: [] };
+}
+
+function extractResponseText(response) {
+  if (!response) {
+    return '';
+  }
+
+  if (typeof response.output_text === 'string') {
+    return response.output_text;
+  }
+
+  const outputItems = Array.isArray(response.output) ? response.output : [];
+  for (const item of outputItems) {
+    const contentBlocks = Array.isArray(item?.content) ? item.content : [];
+    for (const block of contentBlocks) {
+      if (typeof block?.text === 'string') {
+        return block.text;
+      }
+      if (typeof block?.output_text === 'string') {
+        return block.output_text;
+      }
+    }
+  }
+
+  return '';
+}
+
+function normaliseStudents(students) {
+  if (!Array.isArray(students)) {
+    return [];
+  }
+
+  return students
+    .map((student) => ({
+      nombre: normaliseText(student?.nombre),
+      apellido: normaliseText(student?.apellido),
+      dni: normaliseDocument(student?.dni)
+    }))
+    .filter((student) => student.nombre || student.apellido || student.dni);
+}
+
+function normaliseWarnings(warnings) {
+  if (!Array.isArray(warnings)) {
+    return [];
+  }
+
+  return warnings
+    .map((warning) => normaliseText(warning))
+    .filter((warning) => warning.length > 0);
+}
+
+function translateOpenAiError(error) {
+  if (!error) {
+    return 'No se ha podido procesar el documento con OpenAI. Inténtalo de nuevo.';
+  }
+
+  if (error.status === 401) {
+    return 'OpenAI ha rechazado la solicitud. Revisa la configuración de la API.';
+  }
+
+  if (error.status === 429) {
+    return 'Se ha alcanzado el límite de peticiones a OpenAI. Inténtalo de nuevo en unos minutos.';
+  }
+
+  if (error.status === 413) {
+    return 'El archivo es demasiado grande para procesarlo. Reduce su tamaño e inténtalo de nuevo.';
+  }
+
+  if (error?.message) {
+    return normaliseText(error.message) || 'No se ha podido procesar el documento en OpenAI.';
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return 'No se ha podido procesar el documento en OpenAI.';
+}
+
+function buildOpenAiError(status, payload) {
+  const error = new Error(payload?.error?.message || payload?.message || 'Error al comunicar con OpenAI.');
+  error.status = status || 500;
+  return error;
+}
+
+async function safeJson(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
+}
+
+function normaliseText(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return String(value)
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normaliseDocument(value) {
+  const text = normaliseText(value);
+  if (!text) {
+    return '';
+  }
+
+  return text.replace(/\s+/g, '').toUpperCase();
+}
+
+function normaliseFileName(value) {
+  const text = normaliseText(value);
+  if (!text) {
+    return 'documento';
+  }
+
+  return text.split(/[/\\]/).pop();
+}

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -306,6 +306,76 @@ body {
   font-size: 1rem;
 }
 
+.document-upload-dropzone {
+  position: relative;
+  border: 2px dashed rgba(44, 92, 197, 0.35);
+  border-radius: var(--brand-radius);
+  padding: 2.5rem 1.5rem;
+  background-color: #ffffff;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.document-upload-dropzone:focus,
+.document-upload-dropzone:focus-visible {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 0.25rem rgba(44, 92, 197, 0.15);
+}
+
+.document-upload-dropzone.is-dragover,
+.document-upload-dropzone.has-file {
+  border-color: var(--brand-primary);
+  background-color: rgba(44, 92, 197, 0.04);
+}
+
+.document-upload-dropzone.is-invalid {
+  border-color: #dc3545;
+  background-color: rgba(220, 53, 69, 0.04);
+}
+
+.document-upload-dropzone.is-uploading {
+  cursor: progress;
+  opacity: 0.75;
+}
+
+.document-upload-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.document-upload-illustration {
+  width: 72px;
+  height: 72px;
+  margin-bottom: 0.5rem;
+}
+
+.document-upload-title {
+  font-weight: 600;
+  color: #1f274d;
+}
+
+.document-upload-subtitle {
+  color: #4f5b8f;
+}
+
+.document-upload-action {
+  pointer-events: none;
+}
+
+.document-upload-dropzone.has-file .document-upload-action,
+.document-upload-dropzone.has-file .document-upload-subtitle {
+  display: none;
+}
+
+.document-upload-selected-file {
+  word-break: break-word;
+}
+
 @media (max-width: 991.98px) {
   .card-body {
     padding: 2rem;
@@ -326,5 +396,16 @@ body {
   #students-table td[data-label='Fecha'] .form-control,
   #students-table td[data-label='2ª Fecha'] .form-control {
     min-width: 0;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .document-upload-dropzone {
+    padding: 2rem 1.25rem;
+  }
+
+  .document-upload-illustration {
+    width: 60px;
+    height: 60px;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -77,15 +77,18 @@
           <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
             <h2 class="h4 mb-0">Listado de alumnos</h2>
             <div class="d-flex flex-wrap gap-2">
+              <button class="btn btn-success" type="button" id="add-manual-row">
+                Añadir fila
+              </button>
+              <button class="btn btn-outline-primary" type="button" id="upload-document-button">
+                Subir DOC
+              </button>
               <button
                 class="btn btn-outline-secondary"
                 type="button"
                 id="clear-storage"
               >
                 Vaciar listado
-              </button>
-              <button class="btn btn-success" type="button" id="add-manual-row">
-                Añadir fila
               </button>
               <button class="btn btn-primary" type="button" id="generate-all-certificates">
                 Todos PDF's
@@ -328,6 +331,121 @@
           <div class="modal-footer">
             <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
             <button type="submit" form="email-form" class="btn btn-primary" id="email-send-button">Enviar correo</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="modal fade"
+      id="document-upload-modal"
+      tabindex="-1"
+      aria-labelledby="document-upload-modal-label"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-5" id="document-upload-modal-label">Subir documento de alumnado</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <form id="document-upload-form" class="vstack gap-4" novalidate>
+              <div>
+                <label for="document-upload-budget" class="form-label">Número de presupuesto</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="document-upload-budget"
+                  name="document-upload-budget"
+                  placeholder="Introduce el número de presupuesto"
+                  autocomplete="off"
+                  required
+                />
+                <div class="form-text">Utilizaremos este presupuesto para completar la información de la formación.</div>
+              </div>
+
+              <div>
+                <label for="document-upload-file-input" class="form-label">Documento del alumnado</label>
+                <div class="document-upload-dropzone" id="document-upload-dropzone" role="button" tabindex="0">
+                  <div class="document-upload-placeholder">
+                    <svg
+                      class="document-upload-illustration"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 64 64"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        fill="var(--brand-primary)"
+                        d="M40 4H16a4 4 0 0 0-4 4v48a4 4 0 0 0 4 4h32a4 4 0 0 0 4-4V20L40 4z"
+                        opacity="0.1"
+                      ></path>
+                      <path
+                        fill="var(--brand-primary)"
+                        d="M40 4H16a4 4 0 0 0-4 4v48a4 4 0 0 0 4 4h32a4 4 0 0 0 4-4V20z"
+                        opacity="0.08"
+                      ></path>
+                      <path
+                        fill="var(--brand-primary)"
+                        d="M40 4v12a4 4 0 0 0 4 4h12"
+                        opacity="0.2"
+                      ></path>
+                      <path
+                        fill="none"
+                        stroke="var(--brand-primary)"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M40 4H16a4 4 0 0 0-4 4v48a4 4 0 0 0 4 4h32a4 4 0 0 0 4-4V20z"
+                      ></path>
+                      <path
+                        fill="none"
+                        stroke="var(--brand-primary)"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M40 4v12a4 4 0 0 0 4 4h12"
+                      ></path>
+                      <path
+                        fill="none"
+                        stroke="var(--brand-primary)"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="m22 34 6 6 14-14"
+                      ></path>
+                    </svg>
+                    <p class="document-upload-title mb-1">Arrastra y suelta el documento aquí</p>
+                    <p class="document-upload-subtitle mb-3">Admite PDF, Excel o imagen (máx. 10&nbsp;MB)</p>
+                    <span class="document-upload-action btn btn-outline-primary btn-sm">Seleccionar archivo</span>
+                    <p class="document-upload-selected-file text-body-secondary small mb-0 d-none" id="document-upload-file-name"></p>
+                  </div>
+                  <input
+                    type="file"
+                    class="visually-hidden"
+                    id="document-upload-file-input"
+                    name="document-upload-file-input"
+                    accept=".pdf,.xls,.xlsx,.csv,.ods,image/*"
+                  />
+                </div>
+                <div class="form-text">Procesaremos el archivo con OpenAI para obtener los nombres y documentos del alumnado.</div>
+              </div>
+
+              <div id="document-upload-error" class="alert alert-danger d-none" role="alert"></div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" form="document-upload-form" class="btn btn-primary" id="document-upload-submit">
+              <span
+                class="spinner-border spinner-border-sm align-middle me-2 d-none"
+                id="document-upload-submit-spinner"
+                role="status"
+                aria-hidden="true"
+              ></span>
+              <span class="align-middle" id="document-upload-submit-label">Procesar documento</span>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Añadí el botón "Subir DOC" y un nuevo modal con zona de arrastre para recoger presupuestos y documentos de alumnado.
- Implementé la lógica en el cliente para validar archivos, subirlos al backend, integrar la respuesta de OpenAI y añadir alumn@s sin duplicados al listado.
- Creé una función serverless que envía el archivo a OpenAI, aplica el esquema JSON esperado y devuelve los alumnos y avisos detectados.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03717f8288328a46b34eed3d63623