### PR TITLE
Actualizar formato de respuesta en la API de OpenAI

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -201,8 +201,8 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
         ]
       }
     ],
-    response_format: {
-      type: 'json_schema',
+    text: {
+      format: 'json_schema',
       json_schema: {
         name: 'students_payload',
         schema: {


### PR DESCRIPTION
## Summary
- actualizar la solicitud a la API de Responses para usar `text.format` con el esquema JSON requerido

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03ce3eecc8328bb89e37160842a6a