### PR TITLE
Update system prompt content type for responses API

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -175,7 +175,7 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
         role: 'system',
         content: [
           {
-            type: 'text',
+            type: 'input_text',
             text:
               'Eres un asistente que ayuda a un equipo de formación a extraer listados de alumnado. '
               + 'Cuando recibas un documento deberás identificar a todos los alumnos y alumnas, '


### PR DESCRIPTION
## Summary
- update the system message content type to use `input_text` so the Responses API accepts the prompt payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d042b1fd7483288265039aef94c359