### PR TITLE
Fix OpenAI response format schema handling

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -201,8 +201,8 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
         ]
       }
     ],
-    text: {
-      format: 'json_schema',
+    response_format: {
+      type: 'json_schema',
       json_schema: {
         name: 'students_payload',
         schema: {
@@ -340,6 +340,13 @@ function extractResponseText(response) {
       }
       if (typeof block?.output_text === 'string') {
         return block.output_text;
+      }
+      if (block?.json && typeof block.json === 'object') {
+        try {
+          return JSON.stringify(block.json);
+        } catch (error) {
+          console.warn('No se ha podido serializar el JSON de la respuesta de OpenAI.', error);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- replace the deprecated text.json_schema payload with the new response_format.json_schema structure when calling the Responses API
- add defensive handling for json blocks in the OpenAI response to keep supporting JSON schema outputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d044ccae008328b0e4702d00c05287