### PR TITLE
Fix OpenAI response format parameter

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -201,35 +201,37 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
         ]
       }
     ],
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        name: 'students_payload',
-        schema: {
-          type: 'object',
-          additionalProperties: false,
-          properties: {
-            students: {
-              type: 'array',
-              items: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  nombre: { type: 'string', description: 'Nombre de pila del alumno o alumna.' },
-                  apellido: { type: 'string', description: 'Apellidos del alumno o alumna.' },
-                  dni: { type: 'string', description: 'Documento identificativo (DNI, NIE, etc.).' }
-                },
-                required: ['nombre', 'apellido', 'dni']
+    text: {
+      format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'students_payload',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              students: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    nombre: { type: 'string', description: 'Nombre de pila del alumno o alumna.' },
+                    apellido: { type: 'string', description: 'Apellidos del alumno o alumna.' },
+                    dni: { type: 'string', description: 'Documento identificativo (DNI, NIE, etc.).' }
+                  },
+                  required: ['nombre', 'apellido', 'dni']
+                }
+              },
+              warnings: {
+                type: 'array',
+                items: { type: 'string' }
               }
             },
-            warnings: {
-              type: 'array',
-              items: { type: 'string' }
-            }
+            required: ['students']
           },
-          required: ['students']
-        },
-        strict: true
+          strict: true
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- update the OpenAI responses payload to use the new `text.format` block instead of the deprecated `response_format`
- preserve the existing JSON schema definition for student extraction when calling the Responses API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d058411bec8328a205aa8b5d69c284