### PR TITLE
Add name attribute to OpenAI response format schema

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -204,6 +204,7 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
     text: {
       format: {
         type: 'json_schema',
+        name: 'students_payload',
         json_schema: {
           name: 'students_payload',
           schema: {


### PR DESCRIPTION
## Summary
- add the `students_payload` name attribute to the OpenAI text response format configuration

## Testing
- node - <<'NODE' … (manual upload simulation)

------
https://chatgpt.com/codex/tasks/task_e_68d05ddd85f08328a13346f8b222cae0