### PR TITLE
Ensure warnings included in OpenAI response schema

### DIFF
--- a/netlify/functions/process-document.js
+++ b/netlify/functions/process-document.js
@@ -227,7 +227,7 @@ async function requestOpenAiExtraction(fileId, authorisationHeader) {
               items: { type: 'string' }
             }
           },
-          required: ['students']
+          required: ['students', 'warnings']
         },
         strict: true
       }


### PR DESCRIPTION
## Summary
- include the warnings property in the JSON schema required list for OpenAI extraction results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0651374088328a11acd22d8d48b9b