### PR TITLE
Actualizar correo de CC a administracion@gepgroup.es

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -8,7 +8,7 @@
     'Luís Vicent Pérez - Irata: 1/175398',
     'Isaac El Allaoui Algaba: Técnico Irata: 1/248469'
   ];
-  const ACCOUNTING_EMAIL = 'contabilidad@gepgroup.es';
+  const ACCOUNTING_EMAIL = 'administracion@gepgroup.es';
   const EMAIL_SEPARATOR = ';';
   const EMAIL_LIST_DELIMITER_PATTERN = /[;,]+/;
   const EMAIL_VALIDATION_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/public/index.html
+++ b/public/index.html
@@ -298,7 +298,7 @@
                   class="form-control"
                   id="email-cc"
                   name="email-cc"
-                  value="contabilidad@gepgroup.es"
+                  value="administracion@gepgroup.es"
                   autocomplete="off"
                   inputmode="email"
                   spellcheck="false"


### PR DESCRIPTION
## Summary
- Actualizo la constante de correo de contabilidad para apuntar a administracion@gepgroup.es
- Ajusto el valor por defecto del campo CC en el modal de envío de correo

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1098654648328b9bfb40b75e06d0c