### PR TITLE
Resalta campos clave en certificados PDF

### DIFF
--- a/public/assets/js/certificate-pdf.js
+++ b/public/assets/js/certificate-pdf.js
@@ -365,19 +365,35 @@
     return [name, surname].filter(Boolean).join(' ').trim() || 'Nombre del alumno/a';
   }
 
-  function buildDocumentSentence(row) {
+  function buildDocumentSentenceFragments(row) {
     const documentType = normaliseText(row.documentType).toUpperCase();
     const documentNumber = normaliseText(row.dni);
+
     if (!documentType && !documentNumber) {
-      return 'con documento de identidad';
+      return [{ text: 'con documento de identidad' }];
     }
+
     if (!documentType) {
-      return `con documento ${documentNumber}`;
+      return [
+        { text: 'con documento ' },
+        { text: documentNumber, bold: true }
+      ];
     }
+
     if (!documentNumber) {
-      return `con ${documentType}`;
+      return [{ text: `con ${documentType}` }];
     }
-    return `con ${documentType} ${documentNumber}`;
+
+    return [
+      { text: `con ${documentType} ` },
+      { text: documentNumber, bold: true }
+    ];
+  }
+
+  function buildDocumentSentence(row) {
+    return buildDocumentSentenceFragments(row)
+      .map((fragment) => (fragment && typeof fragment.text === 'string' ? fragment.text : ''))
+      .join('');
   }
 
   function formatTrainingDate(value) {
@@ -688,7 +704,7 @@
       referencePageMargins[3]
     ];
     const fullName = buildFullName(row);
-    const documentSentence = buildDocumentSentence(row);
+    const documentSentenceFragments = buildDocumentSentenceFragments(row);
     const trainingDate = formatTrainingDateRange(row.fecha, row.segundaFecha);
     const location = formatLocation(row.lugar);
     const duration = formatDuration(row.duracion);
@@ -706,9 +722,18 @@
         style: 'introText'
       },
       { text: 'CERTIFICADO', style: 'certificateTitle' },
-      { text: `A nombre del alumno/a ${fullName}`, style: 'bodyText' },
       {
-        text: `${documentSentence}, quien en fecha ${trainingDate} y en ${location}`,
+        text: [
+          'A nombre del alumno/a ',
+          { text: fullName, bold: true }
+        ],
+        style: 'bodyText'
+      },
+      {
+        text: [
+          ...documentSentenceFragments,
+          { text: `, quien en fecha ${trainingDate} y en ${location}` }
+        ],
         style: 'bodyText'
       },
       {


### PR DESCRIPTION
## Summary
- añade fragmentos de texto para resaltar el nombre completo del alumno en el certificado PDF
- aplica negrita al número de documento utilizando fragmentos reutilizables para la frase del documento

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d109422d888328ba0e1d4e194c8af3